### PR TITLE
[FIX] ADS-56-00-1808-12070: Slow Order Confirmation and changes to a …

### DIFF
--- a/sale_order_mass_confirm/wizard/sale_order_confirm.py
+++ b/sale_order_mass_confirm/wizard/sale_order_confirm.py
@@ -4,6 +4,10 @@
 
 from odoo import models, api
 
+from datetime import datetime
+import logging
+_logger = logging.getLogger(__name__)
+
 
 class SaleOrderConfirmWizard(models.TransientModel):
     _name = "sale.order.confirm.wizard"
@@ -11,9 +15,16 @@ class SaleOrderConfirmWizard(models.TransientModel):
 
     @api.multi
     def confirm_sale_orders(self):
+        _logger.info("\n\n***Start Mass Order Confirmation.")
+        start_time = datetime.now()
         self.ensure_one()
         active_ids = self._context.get('active_ids')
         orders = self.env['sale.order'].browse(active_ids)
+        order_cnt = 1
         for order in orders:
+            _logger.info("\n%s. Confirming Order:  %s\n" % (str(order_cnt), order.name))
+            order_cnt += 1
             if order.state in ['draft', 'sent']:
                 order.action_confirm()
+            self.env.cr.commit()
+        _logger.info("\n\n***End Mass Order Confirmation %s\n\n" % str(datetime.now()-start_time) )

--- a/sale_order_mass_confirm/wizard/sale_order_confirm.xml
+++ b/sale_order_mass_confirm/wizard/sale_order_confirm.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <form string="Confirm Sale Orders">
                 <footer>
-                    <button name="confirm_sale_orders" string="Confirm" type="object" class="oe_highlight"/>
+                    <button name="confirm_sale_orders" string="Confirm" type="object" class="oe_highlight" context="{'so_mass_confirm': True}"/>
                     or
                     <button string="Cancel" class="oe_link" special="cancel" />
                 </footer>


### PR DESCRIPTION
…SO running slow

Points of Improving the Process:
In Module sale_order_mass_confirm:
a. Added context keyword to identiy for BUlk SO Confirmation
b. To immediately commit once 1 Order is processed and not to wait the entire SO to be completed.
     Issue found when 500 SO's are to be confirmed and in #450  SO the process Time Out, Then all orders from 1-449 will
     not be processed or ignored.
c. Create a log to easy debug the process.